### PR TITLE
Update compose for CPU local deployment

### DIFF
--- a/cardiac-component-segmentation-ai/visheart-local-deployment/docker-compose.yml
+++ b/cardiac-component-segmentation-ai/visheart-local-deployment/docker-compose.yml
@@ -176,13 +176,13 @@ services:
     restart: unless-stopped
     ports:
       - "8001:8001"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
     environment:
       USE_GPU: "true" # Set to "true" if GPU is available
       JWT_SECRET: LOCAL-GPU-JWT-SECRET-CHANGE-IN-PRODUCTION-67890


### PR DESCRIPTION
Commented out NVIDIA GPU device reservations in the `gpu` service mapping to prevent Docker daemon errors when executing on environments without dedicated NVIDIA adapters.