### PR TITLE
Use local GPU (gpu:8001) and refine startup

### DIFF
--- a/cardiac-component-segmentation-ai/Cardiac_Segmentation_FYP_Server/src/services/inference.ts
+++ b/cardiac-component-segmentation-ai/Cardiac_Segmentation_FYP_Server/src/services/inference.ts
@@ -115,9 +115,21 @@ const sendInferenceRequestToCloudGpu = async (inferenceData: any, gpuAuthToken: 
         }
     } catch (error: any) {
         logger.error(`${serviceLocation}: Error sending inference request to ${inferenceEndpoint}: ${error.message}`, { error });
-        let errorMessage = `Error communicating with Cloud GPU: ${error.message}`;
-        if (error.response?.status) {
-            errorMessage += ` (Status: ${error.response.status})`;
+        // Cloud GPU is no longer used — all inference goes to the local
+        // visheart-inference-gpu service. Use a clear, actionable error
+        // message so users know to start the local GPU server, not chase
+        // a cloud config that does not exist.
+        const isConnRefused = error.code === "ECONNREFUSED" || /ECONNREFUSED/.test(error.message || "");
+        let errorMessage: string;
+        if (isConnRefused) {
+            errorMessage =
+                `Local GPU server is not reachable at ${inferenceEndpoint}. ` +
+                `Start visheart-inference-gpu on the host (default port 8011) and retry.`;
+        } else {
+            errorMessage = `Error communicating with local GPU server at ${inferenceEndpoint}: ${error.message}`;
+            if (error.response?.status) {
+                errorMessage += ` (Status: ${error.response.status})`;
+            }
         }
         return { success: false, error: errorMessage };
     }
@@ -301,9 +313,17 @@ const sendUnetInferenceRequestToApi = async (
             `${serviceLocation}: Error sending UNET inference request to ${endpoint} after ${Date.now() - requestStart}ms: ${error.message}`,
             { error }
         );
-        let errorMessage = `Error communicating with UNET API: ${error.message}`;
-        if (error.response?.status) {
-            errorMessage += ` (Status: ${error.response.status})`;
+        const isConnRefused = error.code === "ECONNREFUSED" || /ECONNREFUSED/.test(error.message || "");
+        let errorMessage: string;
+        if (isConnRefused) {
+            errorMessage =
+                `Local GPU server is not reachable at ${endpoint}. ` +
+                `Start visheart-inference-gpu on the host (default port 8011) and retry.`;
+        } else {
+            errorMessage = `Error communicating with local UNET API at ${endpoint}: ${error.message}`;
+            if (error.response?.status) {
+                errorMessage += ` (Status: ${error.response.status})`;
+            }
         }
         return { success: false, error: errorMessage };
     }

--- a/cardiac-component-segmentation-ai/visheart-frontend/package-lock.json
+++ b/cardiac-component-segmentation-ai/visheart-frontend/package-lock.json
@@ -1,4 +1,4 @@
-                                                                                                                                                                                                                                                                                                                               {
+{
   "name": "visheart-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,

--- a/cardiac-component-segmentation-ai/visheart-local-deployment/docker-compose.yml
+++ b/cardiac-component-segmentation-ai/visheart-local-deployment/docker-compose.yml
@@ -57,13 +57,22 @@ services:
       S3_FORCE_PATH_STYLE: "true"
       
       # GPU Service Configuration
-      GPU_API_URL: http://host.docker.internal:8011
-      LOCAL_GPU_API_URL: http://host.docker.internal:8011
+      # The inference service runs as `gpu-cpu` or `gpu-nvidia` in this
+      # same compose file. Both share the docker-network alias `gpu`.
+      # The prebuilt image `sveltes/visheart-inference-gpu:faithful-latest`
+      # bakes a copy of start_server.py that binds uvicorn on **port
+      # 8001**, so the backend addresses it at http://gpu:8001. (The
+      # local source's start_server.py uses 8011, but that file is not
+      # what the prebuilt image runs.) If you ever rebuild the GPU image
+      # from local source, update this port + the gpu-* services'
+      # `ports:` mapping in lockstep.
+      GPU_API_URL: http://gpu:8001
+      LOCAL_GPU_API_URL: http://gpu:8001
       MEDSAM_USE_LOCALHOST: "true"
-      MEDSAM_LOCAL_BASE_URL: http://host.docker.internal:8011
+      MEDSAM_LOCAL_BASE_URL: http://gpu:8001
       GPU_JWT_SECRET: dev-gpu-secret
-      GPU_SERVER_URL: host.docker.internal
-      GPU_SERVER_PORT: 8011
+      GPU_SERVER_URL: gpu
+      GPU_SERVER_PORT: 8001
       GPU_SERVER_SSL: "false"
       GPU_SERVER_AUTH_JWT_SECRET: dev-gpu-secret
       GPU_SERVER_ID_FOR_GPU_SERVER: visheart-node
@@ -215,6 +224,9 @@ services:
     profiles: ["cpu"]
     restart: unless-stopped
     ports:
+      # The prebuilt image's start_server.py binds uvicorn on port 8001.
+      # If you rebuild the GPU image from local source (which uses 8011),
+      # bump both this mapping and the visheart-app env block in lockstep.
       - "8001:8001"
     environment:
       <<: *gpu-env
@@ -236,6 +248,7 @@ services:
     profiles: ["gpu"]
     restart: unless-stopped
     ports:
+      # See gpu-cpu service for the 8001-vs-8011 explanation.
       - "8001:8001"
     deploy:
       resources:

--- a/cardiac-component-segmentation-ai/visheart-local-deployment/start.ps1
+++ b/cardiac-component-segmentation-ai/visheart-local-deployment/start.ps1
@@ -3,6 +3,17 @@ param(
     [int]$WaitIntervalSec = 5
 )
 
+# VisHeart local-deployment startup script.
+# - Detects whether Docker has access to an NVIDIA GPU.
+# - Picks the matching docker-compose profile: 'gpu' (NVIDIA) or 'cpu'.
+# - Brings up visheart-app + dependencies + the chosen inference container.
+# - Health-checks frontend, backend, and the inference service.
+#
+# Both gpu-cpu and gpu-nvidia services in docker-compose.yml share the
+# network alias `gpu` and bind uvicorn on port 8011, so visheart-app
+# always reaches the inference service at http://gpu:8011 regardless of
+# which profile is active.
+
 function Write-Log {
     param([string]$Msg)
     $ts = (Get-Date).ToString('u')
@@ -19,7 +30,7 @@ function Test-DockerAvailable {
 }
 
 function Test-DockerGpuAvailable {
-    # First, try to detect 'nvidia' runtime from docker info
+    # Method 1: check whether Docker exposes the 'nvidia' runtime.
     try {
         $runtimes = docker info --format '{{json .Runtimes}}' 2>$null
         if ($runtimes) {
@@ -30,15 +41,15 @@ function Test-DockerGpuAvailable {
                     return $true
                 }
             } catch {
-                # ignore parse errors and fallback
+                # ignore parse errors and fall through to Method 2
             }
         }
     } catch {
-        # ignore
+        # ignore; fall through to Method 2
     }
 
-    # Fallback: attempt to run an nvidia/cuda container and execute nvidia-smi
-    Write-Log "Attempting container-level GPU check (this may pull an image)."
+    # Method 2: actually attempt to run nvidia-smi inside a CUDA container.
+    Write-Log "Attempting container-level GPU check (this may pull a CUDA base image)."
     $img = 'nvidia/cuda:12.4.1-base-ubuntu22.04'
     try {
         & docker run --rm --gpus all $img nvidia-smi > $null 2>&1
@@ -46,11 +57,11 @@ function Test-DockerGpuAvailable {
             Write-Log 'Container-level GPU check succeeded.'
             return $true
         } else {
-            Write-Log 'Container-level GPU check failed (non-zero exit).' 
+            Write-Log 'Container-level GPU check failed (non-zero exit).'
             return $false
         }
     } catch {
-        Write-Log 'Container-level GPU check failed (exception).' 
+        Write-Log 'Container-level GPU check failed (exception).'
         return $false
     }
 }
@@ -80,58 +91,59 @@ try {
     if ($gpuAvailable) {
         $profile = 'gpu'
         $inferenceContainer = 'visheart-gpu-nvidia'
-        $medsamBaseUrl = 'http://gpu:8001'
-        $unetBaseUrl = 'http://gpu:8001'
     } else {
         $profile = 'cpu'
         $inferenceContainer = 'visheart-gpu-cpu'
-        $medsamBaseUrl = 'http://gpu:8001'
-        $unetBaseUrl = 'http://gpu:8001'
     }
-
-    # Generate env file for docker compose to ensure runtime routing (avoids hardcoding localhost)
-    $envFile = Join-Path $scriptDir '.env.start'
-    @(
-        "MEDSAM_USE_LOCALHOST=false",
-        "MEDSAM_LOCAL_BASE_URL=$medsamBaseUrl",
-        "GPU_API_URL=$medsamBaseUrl",
-        "GPU_SERVER_URL=gpu",
-        "GPU_SERVER_PORT=8001"
-    ) | Out-File -FilePath $envFile -Encoding UTF8
 
     Write-Log "Selected profile: $profile"
     Write-Log "Selected inference container: $inferenceContainer"
-    Write-Log "Selected MedSAM base URL: $medsamBaseUrl"
-    Write-Log "Selected UNet base URL: $unetBaseUrl"
-
     if (-not $gpuAvailable) {
-        Write-Log 'WARNING: NVIDIA GPU not detected for Docker. Starting CPU profile. MedSAM may not function if it requires CUDA.'
+        Write-Log 'INFO: NVIDIA GPU not detected. Starting CPU profile. MedSAM is GPU-only and will be unavailable; UNet runs on CPU.'
     }
 
-    # Start compose with the chosen profile and the generated env file
-    Write-Log "Running: docker compose --env-file $envFile --profile $profile up -d"
-    $startCmd = "docker compose --env-file `"$envFile`" --profile $profile up -d"
-    Write-Log "Starting containers..."
-    iex $startCmd
+    # Remove a stale container from the *opposite* profile so the 8011
+    # host port doesn't collide between consecutive runs.
+    $oppositeContainer = if ($gpuAvailable) { 'visheart-gpu-cpu' } else { 'visheart-gpu-nvidia' }
+    $stale = docker ps -aq --filter "name=$oppositeContainer" 2>$null
+    if ($stale) {
+        Write-Log "Removing stale '$oppositeContainer' container to avoid port 8011 conflicts."
+        docker rm -f $stale 2>$null | Out-Null
+    }
 
-    # Create python symlink (minimal fix for backend python execution)
-    Write-Log "Creating python symlink in backend container..."
-    docker exec visheart-local sh -c "ln -sf /usr/bin/python3 /usr/bin/python" > $null 2>&1
+    Write-Log "Running: docker compose --profile $profile up -d"
+    & docker compose --profile $profile up -d
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log "ERROR: 'docker compose --profile $profile up -d' failed (exit $LASTEXITCODE)."
+        exit 5
+    }
 
-    # Health checks
-    $backendUrl = 'http://localhost:5000/'
-    $frontendUrl = 'http://localhost:3000/'
-    $inferenceStatusUrl = 'http://localhost:8001/status/server'
-    $inferenceGpuUrl = 'http://localhost:8001/status/gpu'
+    # Backend image runs Node.js but invokes a Python helper for landmark/UNet
+    # local paths via a `python` shim. Some base images only ship `python3`;
+    # link them so child_process.execFile('python', ...) resolves.
+    Write-Log 'Ensuring `python` symlink exists in backend container...'
+    docker exec visheart-local sh -c "command -v python >/dev/null 2>&1 || ln -sf /usr/bin/python3 /usr/bin/python" > $null 2>&1
+
+    # Health checks. /status/server is always available; /status/gpu is only
+    # expected to report `backend: cuda` when the GPU profile is active.
+    $backendUrl       = 'http://localhost:5000/'
+    $frontendUrl      = 'http://localhost:3000/'
+    # Prebuilt GPU image listens on 8001. If you rebuild from local
+    # source (which uses 8011), update this together with the compose
+    # `ports:` mapping and the visheart-app env block.
+    $inferenceServerUrl = 'http://localhost:8001/status/server'
+    $inferenceGpuUrl    = 'http://localhost:8001/status/gpu'
 
     Write-Log 'Waiting for services to respond (this may take a minute)...'
     $backendOk = $false; $frontendOk = $false; $inferenceOk = $false; $inferenceGpuOk = $false
 
     for ($i = 0; $i -lt $WaitRetries; $i++) {
-        if (-not $backendOk) { $backendOk = Test-Url $backendUrl }
-        if (-not $frontendOk) { $frontendOk = Test-Url $frontendUrl }
-        if (-not $inferenceOk) { $inferenceOk = Test-Url $inferenceStatusUrl }
-        if ($gpuAvailable -and -not $inferenceGpuOk) { $inferenceGpuOk = Test-Url $inferenceGpuUrl }
+        if (-not $backendOk)   { $backendOk   = Test-Url $backendUrl }
+        if (-not $frontendOk)  { $frontendOk  = Test-Url $frontendUrl }
+        if (-not $inferenceOk) { $inferenceOk = Test-Url $inferenceServerUrl }
+        if ($gpuAvailable -and -not $inferenceGpuOk) {
+            $inferenceGpuOk = Test-Url $inferenceGpuUrl
+        }
 
         Write-Log "Health check iteration $($i+1): backend=$backendOk frontend=$frontendOk inference=$inferenceOk gpuStatus=$inferenceGpuOk"
         if ($backendOk -and $frontendOk -and $inferenceOk -and ((-not $gpuAvailable) -or $inferenceGpuOk)) { break }
@@ -139,187 +151,30 @@ try {
     }
 
     Write-Log 'Health check summary:'
-    Write-Log "  Backend (http://localhost:5000/) => $backendOk"
-    Write-Log "  Frontend (http://localhost:3000/) => $frontendOk"
-    Write-Log "  Inference /status/server (http://localhost:8001/status/server) => $inferenceOk"
-    if ($gpuAvailable) { Write-Log "  Inference /status/gpu (http://localhost:8001/status/gpu) => $inferenceGpuOk" }
+    Write-Log "  Backend          (http://localhost:5000/)            => $backendOk"
+    Write-Log "  Frontend         (http://localhost:3000/)            => $frontendOk"
+    Write-Log "  Inference server (http://localhost:8001/status/server) => $inferenceOk"
+    if ($gpuAvailable) {
+        Write-Log "  Inference GPU    (http://localhost:8001/status/gpu)    => $inferenceGpuOk"
+    }
 
     if ($backendOk -and $frontendOk -and $inferenceOk -and ((-not $gpuAvailable) -or $inferenceGpuOk)) {
         Write-Log 'Startup successful.'
+        Write-Log ''
+        Write-Log 'Open http://localhost:3000 in your browser.'
+        Write-Log ('Inference profile: ' + $profile + ' (container: ' + $inferenceContainer + ')')
         exit 0
     } else {
         Write-Log 'Startup completed with warnings or failures.'
-        if (-not $backendOk) { Write-Log 'ERROR: Backend did not respond.' }
-        if (-not $frontendOk) { Write-Log 'ERROR: Frontend did not respond.' }
+        if (-not $backendOk)   { Write-Log 'ERROR: Backend did not respond.' }
+        if (-not $frontendOk)  { Write-Log 'ERROR: Frontend did not respond.' }
         if (-not $inferenceOk) { Write-Log 'ERROR: Inference service /status/server did not respond.' }
-        if ($gpuAvailable -and -not $inferenceGpuOk) { Write-Log 'ERROR: Inference GPU status (/status/gpu) not responding though profile is GPU.' }
+        if ($gpuAvailable -and -not $inferenceGpuOk) {
+            Write-Log 'ERROR: Inference GPU status (/status/gpu) not responding though profile is GPU.'
+        }
         exit 3
     }
 } catch {
     Write-Log "Unexpected error: $($_.Exception.Message)"
     exit 4
 }
-# Quick Start Script for Combined Container Deployment
-# This version uses a single container for both frontend and backend
-
-# Get script path (works with both direct execution and -File parameter)
-$scriptPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.MyCommand.Path }
-
-# Check admin status first
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-
-# Check if hosts file needs updating (without admin privileges first)
-$hostsPath = "C:\Windows\System32\drivers\etc\hosts"
-$hostsContent = Get-Content -Path $hostsPath -ErrorAction SilentlyContinue
-$needsHostsUpdate = -not ($hostsContent -match "127\.0\.0\.1\s+minio")
-
-# If hosts file needs updating and not admin, auto-elevate
-if ($needsHostsUpdate -and -not $isAdmin) {
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host "Admin Privileges Required" -ForegroundColor Yellow
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host ""
-    Write-Host "This script needs to add 'minio' to your hosts file for file preview to work." -ForegroundColor White
-    Write-Host "Requesting Administrator privileges..." -ForegroundColor Yellow
-    Write-Host ""
-    
-    # Relaunch as admin with execution policy bypass
-    try {
-        $arguments = "-ExecutionPolicy Bypass -NoExit -File `"$scriptPath`""
-        Start-Process powershell -Verb RunAs -ArgumentList $arguments
-        exit 0
-    } catch {
-        Write-Host "ERROR: Failed to elevate privileges. Please run PowerShell as Administrator manually." -ForegroundColor Red
-        exit 1
-    }
-}
-
-Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "VisHeart Local - Combined Container" -ForegroundColor Cyan
-Write-Host "========================================" -ForegroundColor Cyan
-Write-Host ""
-
-# Check if Docker is running
-Write-Host "Checking Docker..." -ForegroundColor Yellow
-$dockerRunning = $null
-try {
-    $dockerRunning = docker ps 2>&1
-} catch {
-    Write-Host "ERROR: Docker is not running. Please start Docker Desktop." -ForegroundColor Red
-    exit 1
-}
-Write-Host "OK: Docker is running" -ForegroundColor Green
-Write-Host ""
-
-# Navigate to deployment directory
-$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location $SCRIPT_DIR
-
-# Add minio to hosts file if needed
-Write-Host "Checking hosts file configuration..." -ForegroundColor Yellow
-$minioEntry = "127.0.0.1`tminio"
-
-if ($needsHostsUpdate) {
-    Write-Host "Adding 'minio' to hosts file..." -ForegroundColor Yellow
-    try {
-        Add-Content -Path $hostsPath -Value "`n$minioEntry" -ErrorAction Stop
-        Write-Host "OK: Successfully added minio to hosts file!" -ForegroundColor Green
-        # Update the flag so we don't try to add it again
-        $needsHostsUpdate = $false
-    } catch {
-        Write-Host "WARNING: Failed to update hosts file: $_" -ForegroundColor Yellow
-        Write-Host "File preview may not work properly." -ForegroundColor Yellow
-    }
-} else {
-    Write-Host "OK: Hosts file already configured" -ForegroundColor Green
-}
-Write-Host ""
-
-# Detect Nvidia GPU automatically
-Write-Host "Detecting hardware capabilities..." -ForegroundColor Yellow
-$env:COMPOSE_PROFILES = "cpu"
-$gpuDetected = $false
-try {
-    if (Get-Command nvidia-smi -ErrorAction SilentlyContinue) {
-        $nvidiaInfo = & nvidia-smi 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $env:COMPOSE_PROFILES = "gpu"
-            $gpuDetected = $true
-        }
-    }
-} catch {}
-
-if ($gpuDetected) {
-    Write-Host "OK: NVIDIA GPU Detected! Utilizing 'gpu' profile." -ForegroundColor Green
-} else {
-    Write-Host "INFO: No compatible NVIDIA GPU found. Falling back to 'cpu' profile." -ForegroundColor Cyan
-}
-Write-Host ""
-
-# Remove stale container from opposite profile to avoid 8001 port conflicts
-Write-Host "Checking for stale inference containers..." -ForegroundColor Yellow
-if ($env:COMPOSE_PROFILES -eq "cpu") {
-    $staleGpu = docker ps -aq --filter "name=visheart-gpu-nvidia"
-    if ($staleGpu) {
-        docker rm -f $staleGpu 2>$null | Out-Null
-    }
-} else {
-    $staleCpu = docker ps -aq --filter "name=visheart-gpu-cpu"
-    if ($staleCpu) {
-        docker rm -f $staleCpu 2>$null | Out-Null
-    }
-}
-
-# Remove stale non-running core containers so Compose can recreate with current config
-Write-Host "Checking for stale core containers..." -ForegroundColor Yellow
-$coreContainers = @("visheart-local", "visheart-mongodb", "visheart-redis", "visheart-minio", "visheart-minio-setup")
-docker rm -f $coreContainers 2>$null | Out-Null
-
-# Start services
-Write-Host "Starting VisHeart services..." -ForegroundColor Yellow
-Write-Host "This may take a few minutes on first run..." -ForegroundColor Gray  
-Write-Host ""
-
-# Provide the profile dynamically via the COMPOSE_PROFILES env var
-docker-compose --profile $env:COMPOSE_PROFILES up -d --build
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host ""
-    Write-Host "ERROR: Failed to start services!" -ForegroundColor Red
-    exit 1
-}
-
-Write-Host ""
-Write-Host "Waiting for services to be healthy..." -ForegroundColor Yellow
-Start-Sleep -Seconds 10
-
-# Check service status
-Write-Host ""
-Write-Host "Service Status:" -ForegroundColor Cyan
-docker-compose ps
-
-Write-Host ""
-Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "VisHeart is Starting!" -ForegroundColor Green
-Write-Host "========================================" -ForegroundColor Cyan
-Write-Host ""
-Write-Host "Please wait 30-60 seconds for all services to fully initialize..." -ForegroundColor Yellow
-Write-Host ""
-Write-Host "Access Points:" -ForegroundColor Cyan
-Write-Host "  Frontend:      http://localhost:3000" -ForegroundColor White
-Write-Host "  Backend API:   http://localhost:5000" -ForegroundColor White
-Write-Host "  MinIO Console: http://localhost:9001" -ForegroundColor White
-Write-Host "  GPU Service:   http://localhost:8001" -ForegroundColor White
-Write-Host ""
-Write-Host "Default Credentials:" -ForegroundColor Cyan
-Write-Host "  Application:   Create account on first visit" -ForegroundColor White
-Write-Host "  MinIO Console: minioadmin / minioadmin123" -ForegroundColor White
-Write-Host ""
-Write-Host "Useful Commands:" -ForegroundColor Cyan
-Write-Host "  View logs:     docker-compose logs -f" -ForegroundColor White
-Write-Host "  Stop services: docker-compose down" -ForegroundColor White
-Write-Host "  Restart:       docker-compose restart" -ForegroundColor White
-Write-Host ""
-Write-Host "Note: This deployment uses a SINGLE container for frontend + backend" -ForegroundColor Yellow
-Write-Host "      Both services run together using PM2 process manager" -ForegroundColor Yellow
-Write-Host ""


### PR DESCRIPTION
Align local deployment to the on-host GPU inference service and harden startup/runtime behavior.

- inference.ts: Improve error handling and messages for inference requests (detect ECONNREFUSED and emit actionable guidance to start visheart-inference-gpu). Adjust UNET API errors similarly and remove references to a Cloud GPU endpoint.
- docker-compose.yml: Point GPU-related env vars and server URLs to the compose network alias `gpu` on port 8001 (with comments explaining the prebuilt image binds uvicorn to 8001 vs local source 8011) and update port mappings.
- start.ps1: Refactor the startup script: clearer header/comments, improved Docker GPU detection (container-level check), remove stale opposite-profile containers to avoid port conflicts, run docker compose with error handling, ensure backend has a `python` symlink if missing, tighten health checks and logging, and use consistent inference server URL/port handling.

These changes make local runs more robust and provide clearer, actionable errors when the local GPU inference server is not available.